### PR TITLE
Keys should not be case sensitive, allow multiple vals

### DIFF
--- a/pkg/actions/download.go
+++ b/pkg/actions/download.go
@@ -63,9 +63,9 @@ func Download(c *cli.Context) error {
 	}
 	if err := utils.WriteConfig(lo.Map(data.SshConfig, func(config dto.SshConfigDto, i int) models.Host {
 		return models.Host{
-			Host:         config.Host,
-			Values:       config.Values,
-			IdentityFile: config.IdentityFile,
+			Host:          config.Host,
+			Values:        config.Values,
+			IdentityFiles: config.IdentityFiles,
 		}
 	})); err != nil {
 		return err
@@ -76,5 +76,6 @@ func Download(c *cli.Context) error {
 			return err
 		}
 	}
+	fmt.Println("Successfully downloaded keys.")
 	return nil
 }

--- a/pkg/dto/main.go
+++ b/pkg/dto/main.go
@@ -22,9 +22,9 @@ type KeyDto struct {
 }
 
 type SshConfigDto struct {
-	Host         string            `json:"host"`
-	Values       map[string]string `json:"values"`
-	IdentityFile string            `json:"identity_file"`
+	Host          string              `json:"host"`
+	Values        map[string][]string `json:"values"`
+	IdentityFiles []string            `json:"identity_files"`
 }
 
 type MachineDto struct {

--- a/pkg/models/host.go
+++ b/pkg/models/host.go
@@ -1,7 +1,7 @@
 package models
 
 type Host struct {
-	Host         string            `json:"host"`
-	IdentityFile string            `json:"identity_file"`
-	Values       map[string]string `json:"values"`
+	Host          string              `json:"host"`
+	IdentityFiles []string            `json:"identity_files"`
+	Values        map[string][]string `json:"values"`
 }

--- a/pkg/utils/parseconfig.go
+++ b/pkg/utils/parseconfig.go
@@ -36,12 +36,12 @@ func ParseConfig() ([]models.Host, error) {
 			}
 			currentHost = &models.Host{
 				Host:   strings.TrimPrefix(line, "Host "),
-				Values: make(map[string]string),
+				Values: make(map[string][]string),
 			}
 		} else if re.Match([]byte(line)) {
 			key := re.FindStringSubmatch(line)[1]
 			value := re.FindStringSubmatch(line)[2]
-			if key == "IdentityFile" {
+			if strings.ToLower(key) == "identityfile" {
 				homeDir := user.HomeDir
 				if runtime.GOOS == "windows" {
 					value = strings.ToLower(value)
@@ -49,9 +49,9 @@ func ParseConfig() ([]models.Host, error) {
 				}
 				identityFile := strings.TrimPrefix(value, homeDir)
 				normalizedIdentityFilePath := filepath.ToSlash(identityFile)
-				currentHost.IdentityFile = normalizedIdentityFilePath
+				currentHost.IdentityFiles = append(currentHost.IdentityFiles, normalizedIdentityFilePath)
 			} else {
-				currentHost.Values[key] = value
+				currentHost.Values[key] = append(currentHost.Values[key], value)
 			}
 
 		}

--- a/pkg/utils/write.go
+++ b/pkg/utils/write.go
@@ -31,14 +31,18 @@ func WriteConfig(hosts []models.Host) error {
 		if _, err := file.WriteString(fmt.Sprintf("Host %s\n", host.Host)); err != nil {
 			return err
 		}
-		if host.IdentityFile != "" {
-			if _, err := file.WriteString(fmt.Sprintf("\t%s %s\n", "IdentityFile", filepath.Join(user.HomeDir, host.IdentityFile))); err != nil {
-				return err
+		if host.IdentityFiles != nil {
+			for _, identityFile := range host.IdentityFiles {
+				if _, err := file.WriteString(fmt.Sprintf("\t%s %s\n", "IdentityFile", filepath.Join(user.HomeDir, identityFile))); err != nil {
+					return err
+				}
 			}
 		}
 		for key, value := range host.Values {
-			if _, err := file.WriteString(fmt.Sprintf("\t%s %s\n", key, value)); err != nil {
-				return err
+			for _, item := range value {
+				if _, err := file.WriteString(fmt.Sprintf("\t%s %s\n", key, item)); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/todo.txt
+++ b/todo.txt
@@ -1,8 +1,6 @@
 MUST HAVES:
 - data conflicts - how to resolve merging?
-- currently it is possible to upload a duplicate ssh_configs entry where host, identity_file, etc. are the same. Probably need to figure this one out
 - Allow users to delete certain keys or config entries
-- allow users to obtain a list of their machines
 - test delete code more
 - if EOF is received, need to have nicer error message. Also cleanup better - what if part way thru setup and EOF happens?
 - server seems to sometimes panic when websocket connection gets closed in a strange way.


### PR DESCRIPTION
This PR allows for duplicate keys in the ssh_config and multiple identityfile entries. It also makes identityfile no longer case sensitive.