### PR TITLE
Add known_hosts file syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ For a deep dive into the technicalities of ssh-sync, including its security mode
 - **Simplify SSH Key Management:** Easily sync your SSH keys and configurations across all your devices.
 - **Enhanced Security:** ssh-sync uses advanced cryptographic techniques to ensure your SSH keys are securely transmitted and stored.
 - **Effortless Setup:** With support for Windows, macOS, and Linux, setting up ssh-sync is straightforward, regardless of your operating system.
+- **Known Hosts Sync:** Each entry from your `known_hosts` file is stored individually so machines can rebuild a complete file when downloading.
 
 ## Contributing
 

--- a/pkg/actions/download.go
+++ b/pkg/actions/download.go
@@ -48,6 +48,9 @@ func Download(c *cli.Context) error {
 	}), directory); err != nil {
 		return err
 	}
+	if err := utils.WriteKnownHosts(data.KnownHosts, directory); err != nil {
+		return err
+	}
 	for _, key := range data.Keys {
 		if err := utils.WriteKey(key.Data, key.Filename, directory); err != nil {
 			return err

--- a/pkg/actions/upload.go
+++ b/pkg/actions/upload.go
@@ -68,6 +68,10 @@ func Upload(c *cli.Context) error {
 		return err
 	}
 	hosts := []models.Host{}
+	knownHosts, err := utils.ParseKnownHosts()
+	if err != nil {
+		return err
+	}
 	for _, file := range data {
 		if file.IsDir() || file.Name() == "authorized_keys" {
 			continue
@@ -105,6 +109,19 @@ func Upload(c *cli.Context) error {
 			return err
 		}
 		w, err := multipartWriter.CreateFormField("ssh_config")
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(jsonBytes); err != nil {
+			return err
+		}
+	}
+	if len(knownHosts) > 0 {
+		jsonBytes, err := json.Marshal(knownHosts)
+		if err != nil {
+			return err
+		}
+		w, err := multipartWriter.CreateFormField("known_hosts")
 		if err != nil {
 			return err
 		}

--- a/pkg/dto/main.go
+++ b/pkg/dto/main.go
@@ -7,11 +7,12 @@ type Dto interface {
 }
 
 type DataDto struct {
-	ID        uuid.UUID      `json:"id"`
-	Username  string         `json:"username"`
-	Keys      []KeyDto       `json:"keys"`
-	SshConfig []SshConfigDto `json:"ssh_config"`
-	Machines  []MachineDto   `json:"machines"`
+	ID         uuid.UUID      `json:"id"`
+	Username   string         `json:"username"`
+	Keys       []KeyDto       `json:"keys"`
+	SshConfig  []SshConfigDto `json:"ssh_config"`
+	KnownHosts []string       `json:"known_hosts"`
+	Machines   []MachineDto   `json:"machines"`
 }
 
 type KeyDto struct {

--- a/pkg/retrieval/data_test.go
+++ b/pkg/retrieval/data_test.go
@@ -41,6 +41,7 @@ func TestDownloadData(t *testing.T) {
 						IdentityFiles: []string{"test"},
 					},
 				},
+				KnownHosts: []string{"hostkey"},
 			},
 		})
 	}))

--- a/pkg/utils/knownhosts.go
+++ b/pkg/utils/knownhosts.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"bufio"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+// ParseKnownHosts reads the user's known_hosts file and returns each line.
+func ParseKnownHosts() ([]string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(usr.HomeDir, ".ssh", "known_hosts")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}
+
+// WriteKnownHosts writes the provided lines to the known_hosts file inside sshDirectory.
+func WriteKnownHosts(lines []string, sshDirectory string) error {
+	p, err := GetAndCreateSshDirectory(sshDirectory)
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(filepath.Join(p, "known_hosts"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := bufio.NewWriter(file)
+	for _, line := range lines {
+		if _, err := writer.WriteString(line + "\n"); err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}


### PR DESCRIPTION
## Summary
- support storing and writing `known_hosts`
- expose `KnownHosts` in `DataDto`
- sync known_hosts when downloading or uploading
- document this feature in README

## Testing
- `go test ./...` *(fails: no route to host)*