### PR TITLE
Add Linux ARM packages and repository script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,44 +53,66 @@ jobs:
           name: ssh-sync-setup
           path: ./win-build/Output/ssh-sync-setup.exe
           retention-days: 5
-  build-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ">=1.19.7"
-      - name: Go Build
-        run: go build -o ssh-sync -ldflags "-X main.version=${{github.ref_name}}"
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ssh-sync
-          path: ./ssh-sync
-          retention-days: 5
-      - name: Install FPM
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ruby ruby-dev rubygems build-essential rpm
-          sudo gem install --no-document fpm
+build-linux:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: ">=1.19.7"
+    - name: Build binaries
+      run: |
+        GOOS=linux GOARCH=amd64 go build -o ssh-sync-amd64 -ldflags "-X main.version=${{github.ref_name}}"
+        GOOS=linux GOARCH=arm64 go build -o ssh-sync-arm64 -ldflags "-X main.version=${{github.ref_name}}"
+        cp ssh-sync-amd64 ssh-sync
+    - name: Upload linux binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: ssh-sync
+        path: ./ssh-sync
+        retention-days: 5
+    - name: Install packaging tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ruby ruby-dev rubygems build-essential rpm dpkg-dev createrepo
+        sudo gem install --no-document fpm
+    - name: Create packages
+      run: |
+        mkdir -p packages
+        fpm -s dir -t deb -n ssh-sync -v ${{ github.ref_name }} --description "ssh-sync" \
+          --architecture amd64 --deb-no-default-config-files \
+          ssh-sync-amd64=/usr/local/bin/ssh-sync \
+          -p packages/ssh-sync_${{ github.ref_name }}_amd64.deb
+        fpm -s dir -t deb -n ssh-sync -v ${{ github.ref_name }} --description "ssh-sync" \
+          --architecture arm64 --deb-no-default-config-files \
+          ssh-sync-arm64=/usr/local/bin/ssh-sync \
+          -p packages/ssh-sync_${{ github.ref_name }}_arm64.deb
+        fpm -s dir -t rpm -n ssh-sync -v ${{ github.ref_name }} --description "ssh-sync" \
+          --architecture amd64 \
+          ssh-sync-amd64=/usr/local/bin/ssh-sync \
+          -p packages/ssh-sync-${{ github.ref_name }}-1.x86_64.rpm
+        fpm -s dir -t rpm -n ssh-sync -v ${{ github.ref_name }} --description "ssh-sync" \
+          --architecture arm64 \
+          ssh-sync-arm64=/usr/local/bin/ssh-sync \
+          -p packages/ssh-sync-${{ github.ref_name }}-1.aarch64.rpm
+    - name: Create package repository
+      run: |
+        ./scripts/create-repo.sh repo
+    - name: Upload Linux Packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: |
+          packages/*.deb
+          packages/*.rpm
+        retention-days: 5
+    - name: Upload Repo
+      uses: actions/upload-artifact@v4
+      with:
+        name: package-repo
+        path: repo
+        retention-days: 5
 
-      - name: Create a .deb package
-        run: |
-          fpm -s dir -t deb -n ssh-sync -v ${{ github.ref_name }} --description "ssh-sync" \
-          --deb-no-default-config-files \
-          ./ssh-sync=/usr/local/bin/ssh-sync
-
-      - name: Create an .rpm package
-        run: |
-          fpm -s dir -t rpm -n ssh-sync -v ${{ github.ref_name }} --description "ssh-sync" \
-          ./ssh-sync=/usr/local/bin/ssh-sync
-      - name: Upload Linux Packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: packages
-          path: |
-            *.deb
-            *.rpm
   release:
     needs: [build-docker, build-windows, build-linux]
     runs-on: ubuntu-latest
@@ -100,5 +122,5 @@ jobs:
         uses: actions/download-artifact@v4
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: "./ssh-sync-setup/ssh-sync-setup.exe,./ssh-sync/ssh-sync,./packages/*.deb,./packages/*.rpm"
+          artifacts: "./ssh-sync-setup/ssh-sync-setup.exe,./ssh-sync/ssh-sync,./packages/*.deb,./packages/*.rpm,./repo/**"
           token: ${{ secrets.ACCESS_TOKEN_CLASSIC }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ssh-sync.exe
 ssh-sync-installer.exe
 win-build/Output/
 __debug_bin*
+packages/
+repo/

--- a/README.md
+++ b/README.md
@@ -30,20 +30,22 @@ brew install ssh-sync
 
 #### Linux
 
-For Linux users, download the appropriate package from our [GitHub Releases](https://github.com/therealpaulgg/ssh-sync/releases) page:
+Packages for both <code>amd64</code> and <code>arm64</code> architectures are published to
+our custom package repository at <code>https://packages.sshsync.io</code>.
 
-- For Debian-based distributions (e.g., Ubuntu):
+For Debian-based distributions (e.g., Ubuntu) add the repository and install:
 
 ```shell
-wget <link-to-.deb-file>
-sudo dpkg -i ssh-sync_0.3.8_amd64.deb
+echo "deb [trusted=yes] https://packages.sshsync.io/deb stable main" | sudo tee /etc/apt/sources.list.d/ssh-sync.list
+sudo apt update
+sudo apt install ssh-sync
 ```
 
-- For RPM-based distributions (e.g., Fedora, CentOS):
+For RPM-based distributions (e.g., Fedora, CentOS) use:
 
 ```shell
-wget <link-to-.rpm-file>
-sudo rpm -i ssh-sync-v0.3.8-1.x86_64.rpm
+sudo dnf config-manager --add-repo https://packages.sshsync.io/rpm/ssh-sync.repo
+sudo dnf install ssh-sync
 ```
 
 ## Getting Started with SSH-Sync

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,18 +13,19 @@
 <span class="hljs-keyword">brew </span>install ssh-sync
 </code></pre>
 <h4 id="linux">Linux</h4>
-<p>For Linux users, download the appropriate package from our <a href="https://github.com/therealpaulgg/ssh-sync/releases">GitHub Releases</a> page:</p>
+<p>For Linux users, packages are available from our <a href="https://packages.sshsync.io">package repository</a>:</p>
 <ul>
-<li>For Debian-based distributions (e.g., Ubuntu):</li>
+<li>For Debian-based distributions (e.g., Ubuntu) add our repository and install:</li>
 </ul>
-<pre><code class="lang-shell"><span class="hljs-selector-tag">wget</span> &lt;<span class="hljs-selector-tag">link-to-</span><span class="hljs-selector-class">.deb-file</span>&gt;
-<span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">dpkg</span> <span class="hljs-selector-tag">-i</span> <span class="hljs-selector-tag">ssh-sync_0</span><span class="hljs-selector-class">.3</span><span class="hljs-selector-class">.8_amd64</span><span class="hljs-selector-class">.deb</span>
+<pre><code class="lang-shell"><span class="hljs-selector-tag">echo</span> <span class="hljs-string">"deb [trusted=yes] https://packages.sshsync.io/deb stable main"</span> <span class="hljs-pipe">|</span> <span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">tee</span> <span class="hljs-selector-tag">/etc/apt/sources.list.d/ssh-sync.list</span>
+<span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">apt</span> <span class="hljs-selector-tag">update</span>
+<span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">apt</span> <span class="hljs-selector-tag">install</span> <span class="hljs-selector-tag">ssh-sync</span>
 </code></pre>
 <ul>
 <li>For RPM-based distributions (e.g., Fedora, CentOS):</li>
 </ul>
-<pre><code class="lang-shell"><span class="hljs-selector-tag">wget</span> &lt;<span class="hljs-selector-tag">link-to-</span><span class="hljs-selector-class">.rpm-file</span>&gt;
-<span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">rpm</span> <span class="hljs-selector-tag">-i</span> <span class="hljs-selector-tag">ssh-sync-v0</span><span class="hljs-selector-class">.3</span><span class="hljs-selector-class">.8-1</span><span class="hljs-selector-class">.x86_64</span><span class="hljs-selector-class">.rpm</span>
+<pre><code class="lang-shell"><span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">dnf</span> <span class="hljs-selector-tag">config-manager</span> <span class="hljs-selector-tag">--add-repo</span> <span class="hljs-selector-tag">https://packages.sshsync.io/rpm/ssh-sync.repo</span>
+<span class="hljs-selector-tag">sudo</span> <span class="hljs-selector-tag">dnf</span> <span class="hljs-selector-tag">install</span> <span class="hljs-selector-tag">ssh-sync</span>
 </code></pre>
 <h2 id="getting-started-with-ssh-sync">Getting Started with SSH-Sync</h2>
 <p>SSH-Sync makes managing and syncing your SSH keys across multiple machines effortless. Here&#39;s how to get started:</p>

--- a/scripts/create-repo.sh
+++ b/scripts/create-repo.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build simple apt and rpm repositories from the package files in packages/
+
+REPO_DIR=${1:-repo}
+
+mkdir -p "$REPO_DIR/deb" "$REPO_DIR/rpm"
+# Move packages into the repo
+if compgen -G "packages/*.deb" > /dev/null; then
+  mv packages/*.deb "$REPO_DIR/deb/"
+fi
+if compgen -G "packages/*.rpm" > /dev/null; then
+  mv packages/*.rpm "$REPO_DIR/rpm/"
+fi
+
+if [ -n "$(ls -A "$REPO_DIR/deb" 2>/dev/null)" ]; then
+  dpkg-scanpackages "$REPO_DIR/deb" /dev/null | gzip -9c > "$REPO_DIR/deb/Packages.gz"
+fi
+
+if [ -n "$(ls -A "$REPO_DIR/rpm" 2>/dev/null)" ]; then
+  createrepo "$REPO_DIR/rpm"
+fi


### PR DESCRIPTION
## Summary
- publish Debian and RPM packages for `amd64` and `arm64`
- script to build repo metadata
- distribute repo in releases
- document new Linux repo in README and docs
- ignore generated package directories

## Testing
- `go test ./...` *(fails: no route to host)*