### PR TITLE
Add key file date comparison before upload

### DIFF
--- a/pkg/dto/main.go
+++ b/pkg/dto/main.go
@@ -1,6 +1,10 @@
 package dto
 
-import "github.com/google/uuid"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type Dto interface {
 	DataDto | UserDto | UserMachineDto | ChallengeResponseDto | ChallengeSuccessEncryptedKeyDto | MessageDto | EncryptedMasterKeyDto | MasterKeyDto | PublicKeyDto
@@ -15,10 +19,11 @@ type DataDto struct {
 }
 
 type KeyDto struct {
-	ID       uuid.UUID `json:"id"`
-	UserID   uuid.UUID `json:"user_id"`
-	Filename string    `json:"filename"`
-	Data     []byte    `json:"data"`
+	ID        uuid.UUID  `json:"id"`
+	UserID    uuid.UUID  `json:"user_id"`
+	Filename  string     `json:"filename"`
+	Data      []byte     `json:"data"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 type SshConfigDto struct {

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"bufio"
+	"fmt"
 	"os"
+	"time"
 )
 
 func ReadLineFromStdin(reader *bufio.Scanner, input *string) error {
@@ -14,4 +16,26 @@ func ReadLineFromStdin(reader *bufio.Scanner, input *string) error {
 		return nil
 	}
 	return reader.Err()
+}
+
+// PromptOverwriteNewerKey prompts the user when they're trying to upload a key that's older than the server version
+// Returns true if the user wants to proceed with the upload, false otherwise
+func PromptOverwriteNewerKey(filename string, localTime time.Time, serverTime time.Time) (bool, error) {
+	var answer string
+	scanner := bufio.NewScanner(os.Stdin)
+
+	fmt.Printf("Warning: The server has a newer version of '%s'\n", filename)
+	fmt.Printf("  Local file:  %s\n", localTime.Format("2006-01-02 15:04:05"))
+	fmt.Printf("  Server file: %s\n", serverTime.Format("2006-01-02 15:04:05"))
+	fmt.Println("Do you want to overwrite the newer server version with your older local file?")
+	fmt.Println("1. Yes, overwrite the server file")
+	fmt.Println("2. No, skip this file (recommended)")
+	fmt.Print("Please choose an option (will skip by default): ")
+
+	if err := ReadLineFromStdin(scanner, &answer); err != nil {
+		return false, err
+	}
+	fmt.Println()
+
+	return answer == "1", nil
 }


### PR DESCRIPTION
Implement safety check to prevent accidentally overwriting newer server keys with older local versions during upload. When uploading keys, the client now:

1. Fetches existing keys from the server with their timestamps
2. Compares local file modification times with server timestamps
3. Prompts the user if attempting to overwrite a newer server key
4. Allows user to proceed or skip the file

This mirrors the existing conflict detection on the download side and addresses the warning in the README about upload overwriting without checks.

Changes:
- Add UpdatedAt timestamp field to KeyDto (optional for backward compatibility)
- Add PromptOverwriteNewerKey helper function in utils/io.go
- Modify Upload action to decode server response and compare dates
- Skip files when user chooses not to overwrite newer versions